### PR TITLE
adding an optional currency_map in the config that allow to rename account and commodity

### DIFF
--- a/beancount_ethereum/importer.py
+++ b/beancount_ethereum/importer.py
@@ -37,17 +37,36 @@ class Importer(ImporterProtocol):
         return {key.lower(): value for key, value
                 in self.config['account_map'].items()}
 
+    def account_suffix(self, currency):
+        if 'currency_map' in self.config:
+            for keyval in self.config['currency_map']:
+                if currency.lower() == keyval['blockchain_currency'].lower():
+                    return keyval['account_suffix']
+            return currency
+        else:            
+            return currency
+
+    def beancount_commodity(self, currency):
+        if 'currency_map' in self.config:       
+            for keyval in self.config['currency_map']:
+                if currency.lower() == keyval['blockchain_currency'].lower():
+                    return keyval['beancount_commodity']
+            return currency
+        else:           
+            return currency
+
     def _create_posting(
         self,
         address: str,
         value: D,
         currency: str,
     ) -> tuple:
+
         if address == MINER:
             assert currency == self.config['base_currency']
             account = self.config['fee_account']
             payee = None
-        else:
+        else:            
             if address not in self.account_map:
                 if value == 0:
                     # Do not create posting
@@ -62,12 +81,12 @@ class Importer(ImporterProtocol):
                     # Do not create posting
                     account = None
                 else:
-                    account = f'{self.account_map[address]}:{currency}'
+                    account = f'{self.account_map[address]}:{self.account_suffix(currency)}'
                 payee = None
         if account:
             posting = Posting(
                 account,
-                Amount(value, currency),
+                Amount(value, self.beancount_commodity(currency)),
                 None, None, None, None,
             )
         else:

--- a/beancount_ethereum/importer.py
+++ b/beancount_ethereum/importer.py
@@ -17,7 +17,6 @@ class Importer(ImporterProtocol):
         self,
         config_path='config.json',
         max_delta=90,  # days
-        debug: bool = False
     ):
         with open(config_path, 'r') as config_file:
             self.config = json.load(config_file)
@@ -25,7 +24,6 @@ class Importer(ImporterProtocol):
             datetime.datetime.now() -
             datetime.timedelta(days=max_delta)
         )
-        self.debug = debug
 
     def name(self) -> str:
         return 'ethereum'
@@ -39,21 +37,14 @@ class Importer(ImporterProtocol):
         return {key.lower(): value for key, value
                 in self.config['account_map'].items()}
 
-    def print_debug(self, string):
-        if self.debug:
-            print(string)
-
     def account_suffix(self, currency):
         if 'currency_map' in self.config:
             if currency in self.config['currency_map']:
                     if 'account_suffix' in self.config['currency_map'][currency]:
-                        self.print_debug("currency_map for {} has been found, and account_suffix is set".format(currency))
                         return self.config['currency_map'][currency]['account_suffix']
                     else:
-                        self.print_debug("currency_map for {} has been found, and account_suffix is NOT set: switching to commodity value".format(currency))
                         return self.config['currency_map'][currency]['commodity']
             else:
-                self.print_debug("currency_map for {} has not been found: keeping default".format(currency))
                 return currency
         else:
             return currency

--- a/config.json.example
+++ b/config.json.example
@@ -9,5 +9,17 @@
     "block_explorer_api_url": "http://api.etherscan.io/api",
     "block_explorer_api_key": "ABCD1234",
     "block_explorer_api_request_delay": 0,
-    "base_currency": "ETH"
+    "base_currency": "ETH",
+    "currency_map": [
+        {
+            "blockchain_currency":"USDC.e",
+            "account_suffix": "USDC",
+            "beancount_commodity": "USD"
+        },
+        {
+            "blockchain_currency":"WETH.e",
+            "account_suffix": "ETH",
+            "beancount_commodity": "ETH"
+        }
+    ]
 }

--- a/config.json.example
+++ b/config.json.example
@@ -10,16 +10,8 @@
     "block_explorer_api_key": "ABCD1234",
     "block_explorer_api_request_delay": 0,
     "base_currency": "ETH",
-    "currency_map": [
-        {
-            "blockchain_currency":"USDC.e",
-            "account_suffix": "USDC",
-            "beancount_commodity": "USD"
-        },
-        {
-            "blockchain_currency":"WETH.e",
-            "account_suffix": "ETH",
-            "beancount_commodity": "ETH"
-        }
-    ]
+    "currency_map":  {
+        "USDC.E": {"commodity": "USD", "account_suffix": "USDC"},
+        "WETH.E": {"commodity": "ETH"}
+    }
 }

--- a/import_config.py.example
+++ b/import_config.py.example
@@ -6,5 +6,5 @@ sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 import beancount_ethereum
 
 CONFIG = [
-    beancount_ethereum.importer.Importer(config_path='config.json',debug=False),
+    beancount_ethereum.importer.Importer(config_path='config.json'),
 ]

--- a/import_config.py.example
+++ b/import_config.py.example
@@ -6,5 +6,5 @@ sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 import beancount_ethereum
 
 CONFIG = [
-    beancount_ethereum.importer.Importer(config_path='config.json'),
+    beancount_ethereum.importer.Importer(config_path='config.json',debug=False),
 ]


### PR DESCRIPTION
Hi this PR is a proposal to solve two issue i have met on alternate blockchain:
- On Avalanche, bridged token have a dot in their name (for example: USDC.e) which is a problem as account can't have a dot in their name.
- Also i have some token on XDAI whose name is 20 character long, which is not accepted in beancount.

Thanks to the additional mapping in the config file, i am now able to rename the account suffix and/or the commodity.